### PR TITLE
Fix large play count retrieval on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,5 @@
     "prompt": "^1.3.0",
     "xmldoc": "^0.4.0"
   },
-  "optionalDependencies": {
-    "osa": ""
-  }
+  "optionalDependencies": {}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,10 +30,6 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
-    optionalDependencies:
-      osa:
-        specifier: ''
-        version: 2.5.0
 
 packages:
 
@@ -104,9 +100,6 @@ packages:
   nock@14.0.6:
     resolution: {integrity: sha512-67n1OfusL/ON57fwFJ6ZurSJa/msYVQmqlz9rCel2HJYj4Zeb8v9TcmRdEW+PV2i9Fm2358umSvzZukhw/E8DA==}
     engines: {node: '>=18.20.0 <20 || >=20.12.1'}
-
-  osa@2.5.0:
-    resolution: {integrity: sha512-FZv4/iM4cNXS6ayyj6QQEJXXFxKnuF4UvuC3JYzH3nQNtC3z32vpcwEZdojDGIUglsqjVYWwH2gjvvNuqImuSA==}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -217,9 +210,6 @@ snapshots:
       '@mswjs/interceptors': 0.39.3
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
-
-  osa@2.5.0:
-    optional: true
 
   outvariant@1.4.3: {}
 

--- a/src/providers/OSXProvider.ts
+++ b/src/providers/OSXProvider.ts
@@ -1,10 +1,8 @@
-/* @flow */
-
 import type { ITunesTrackInfo, Provider } from "./Provider";
 
 import { execFile } from "child_process";
 
-const MAX_BUFFER = 10 * 1024 * 1024; // 10MB, supports very large libraries
+const MAX_BUFFER = 1024 * 1024 * 1024; // Track output can be very large
 
 function Application(app: string): any {} // stub for Flow
 


### PR DESCRIPTION
## Summary
- increase buffer limit when executing `osascript`
- drop unused `osa` dependency

Resolves #6 

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687c94791ad48328bd266a7e5fbdb4e8